### PR TITLE
Update comments about mesh-derived counts

### DIFF
--- a/src/Terrain.jsx
+++ b/src/Terrain.jsx
@@ -11,8 +11,8 @@ export default function Terrain() {
 
     const { heights, widthSegs, maxX, minX, maxZ, minZ } = useMemo(() => {
         const posAttr = mesh.geometry.attributes.position
-        const total = posAttr.count   // hard-coded total vertices for test
-        const rows =  Math.sqrt(total)    // hard-coded vertices per row
+        const total = posAttr.count   // total vertex count from mesh geometry
+        const rows =  Math.sqrt(total)    // vertices per row derived from data
         const widthSegs = rows - 1
 
 


### PR DESCRIPTION
## Summary
- clarify that `total` and `rows` come from mesh geometry

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684016b076e48326926e17af8f0de850